### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           key: format-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             format-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e checkformatting
   Lint:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
           key: lint-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             lint-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e lint
   Tests:
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
           key: tests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             tests-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e tests
       - name: Upload coverage file
         uses: actions/upload-artifact@v3
@@ -80,7 +80,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: coverage
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e coverage
   Functests:
     runs-on: ubuntu-latest
@@ -97,5 +97,5 @@ jobs:
           key: functests-${{ runner.os }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements/*') }}
           restore-keys: |
             functests-${{ runner.os }}-tox-
-      - run: python -m pip install tox
+      - run: python -m pip install 'tox<4'
       - run: tox -e functests

--- a/bin/make_python
+++ b/bin/make_python
@@ -12,7 +12,7 @@ for python_version in 3.10.6; do
     bin_dir=$pyenv_root/versions/$python_version/bin
     if [ ! -f "$bin_dir"/tox ]; then
         pyenv install --skip-existing "$python_version"
-        "$bin_dir"/pip install --disable-pip-version-check tox
+        "$bin_dir"/pip install --disable-pip-version-check 'tox<4'
         pyenv rehash
     fi
 done

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.25.0
 requires =
+    tox>=3.25.0,<4
     tox-envfile
     tox-faster
     tox-run-command


### PR DESCRIPTION
The release of tox 4.0.0 to PyPI has broken all our tox commands, for example:

```terminal
$ make checkformatting
...
ImportError: cannot import name 'hookimpl' from 'tox'
```

In some projects I've seen this error message instead:

```
ModuleNotFoundError: No module named 'py'
```

The reason for the breakage is that tox 3.x installs the new tox 4.0.0 in the `.tox/.tox` venv. Breaking changes in tox 4.0.0 then cause problems. In particular tox 4.0.0 breaks compatibility with all tox plugins. Fix this by telling it to install `tox<4`.

At the same time also fix `make_python` to install `tox<4`. This controls the version of the "outer" tox: the instance of tox that `make` actually runs when we have commands like `pyenv exec tox` in `Makefile`. This is just for good measure, I'm not sure that pinning the outer version of tox is strictly necessary: if tox 4.0.0 got installed as the outer version it would see the `tox<4` requirement in our `tox.ini` and would install `tox<4` in the `.tox/.tox` venv and run that.

And the same for `ci.yml`.